### PR TITLE
Add calendar page and due date feature

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -18,6 +18,8 @@ class Todo(db.Model):
     title = db.Column(db.String(200), nullable=False)
     # タスクの詳細（500文字以内、必須ではない）
     details = db.Column(db.String(500), nullable=True)
+    # 締め切り日（オプション）
+    due_date = db.Column(db.Date, nullable=True)
     # タスクの完了状態（デフォルトは未完了）
     completed = db.Column(db.Boolean, default=False)
     # ユーザーID（外部キーとしてUserモデルのIDを参照）

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -1,5 +1,6 @@
 # FlaskのBlueprintをインポートしてルート管理を分離
 from flask import Blueprint, request, jsonify
+from datetime import datetime
 # モデルをインポート（UserとTodo）
 from .models import User, Todo
 # データベース操作用のインスタンスをインポート
@@ -43,7 +44,8 @@ def todos():
                 'id': todo.id,
                 'title': todo.title,
                 'details': todo.details,  # 詳細情報を含める
-                'completed': todo.completed
+                'completed': todo.completed,
+                'due_date': todo.due_date.isoformat() if todo.due_date else None
             } for todo in todos
         ])
     elif request.method == 'POST':  # 新しいタスクの作成
@@ -51,6 +53,7 @@ def todos():
         new_todo = Todo(
             title=data['title'],  # タスクのタイトル
             details=data.get('details'),  # タスクの詳細（オプション）
+            due_date=datetime.strptime(data['due_date'], '%Y-%m-%d').date() if data.get('due_date') else None,
             user_id=data['user_id']  # ユーザーID
         )
         db.session.add(new_todo)
@@ -71,6 +74,8 @@ def update_or_delete_todo(todo_id):
             todo.title = data['title']  # タイトルを更新
         if 'details' in data:
             todo.details = data['details']  # 詳細を更新
+        if 'due_date' in data:
+            todo.due_date = datetime.strptime(data['due_date'], '%Y-%m-%d').date() if data['due_date'] else None
         if 'completed' in data:
             todo.completed = data['completed']  # 完了状態を更新
         db.session.commit()  # 変更を保存

--- a/db/init.sql
+++ b/db/init.sql
@@ -18,6 +18,7 @@ CREATE TABLE IF NOT EXISTS todo (
     id INT AUTO_INCREMENT PRIMARY KEY, -- タスクID（自動増加）
     title VARCHAR(200) NOT NULL, -- タスクのタイトル（必須）
     details VARCHAR(500), -- タスクの詳細（オプション）
+    due_date DATE, -- 締め切り日（オプション）
     completed BOOLEAN DEFAULT FALSE, -- タスクの完了状態（デフォルトは未完了）
     user_id INT NOT NULL, -- ユーザーID（外部キー）
     FOREIGN KEY (user_id) REFERENCES user(id) -- 外部キー制約（ユーザーテーブルのIDを参照）

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import SignUpPage from "./pages/SignUpPage"; // サインアップページ
 import HomePage from "./pages/HomePage"; // ホームページ
 import ListPage from "./pages/ListPage"; // タスクリストページ
 import EditPage from "./pages/EditPage"; // タスク編集ページ
+import CalendarPage from "./pages/CalendarPage"; // カレンダーページ
 
 // アプリケーション全体を管理するコンポーネント
 const App: React.FC = () => {
@@ -23,6 +24,7 @@ const App: React.FC = () => {
         <Route path="/home" element={<HomePage />} /> {/* ホームページ */}
         <Route path="/list" element={<ListPage />} /> {/* タスクリストページ */}
         <Route path="/edit" element={<EditPage />} /> {/* タスク編集ページ */}
+        <Route path="/calendar" element={<CalendarPage />} /> {/* カレンダーページ */}
       </Routes>
     </Router>
   );

--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -1,0 +1,71 @@
+import React, { useEffect, useState } from "react";
+import axios from "axios";
+import {
+  Container,
+  TextField,
+  Typography,
+  Paper,
+  Box,
+  Button
+} from "@mui/material";
+import { useNavigate } from "react-router-dom";
+
+interface Todo {
+  id: number;
+  title: string;
+  details: string | null;
+  completed: boolean;
+  due_date: string | null;
+}
+
+const CalendarPage: React.FC = () => {
+  const [todos, setTodos] = useState<Todo[]>([]);
+  const [selectedDate, setSelectedDate] = useState<string>("");
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const fetchTodos = async () => {
+      try {
+        const response = await axios.get(`${process.env.REACT_APP_API_URL}/todos`);
+        setTodos(response.data);
+      } catch (err) {
+        console.error("Failed to fetch tasks");
+      }
+    };
+    fetchTodos();
+  }, []);
+
+  const filteredTodos = todos.filter(
+    (todo) => todo.due_date === selectedDate
+  );
+
+  return (
+    <Container>
+      <Typography variant="h4" gutterBottom>
+        カレンダー
+      </Typography>
+      <Box mb={2} display="flex" gap={2}>
+        <Button variant="contained" onClick={() => navigate("/home")}>ホームに戻る</Button>
+        <TextField
+          label="日付を選択"
+          type="date"
+          InputLabelProps={{ shrink: true }}
+          value={selectedDate}
+          onChange={(e) => setSelectedDate(e.target.value)}
+        />
+      </Box>
+      {filteredTodos.map((todo) => (
+        <Paper key={todo.id} elevation={3} style={{ padding: "1rem", margin: "0.5rem 0" }}>
+          <Typography variant="h6">{todo.title}</Typography>
+          {todo.details && (
+            <Typography variant="body2" color="textSecondary">
+              {todo.details}
+            </Typography>
+          )}
+        </Paper>
+      ))}
+    </Container>
+  );
+};
+
+export default CalendarPage;

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -13,6 +13,8 @@ const HomePage: React.FC = () => {
   const [task, setTask] = useState(""); // 初期値は空文字
   // ユーザーが入力した詳細情報を管理するstate
   const [details, setDetails] = useState(""); // 初期値は空文字
+  // ユーザーが入力した締め切り日を管理するstate
+  const [dueDate, setDueDate] = useState(""); // 初期値は空文字
   // 入力エラー時のメッセージを管理するstate
   const [error, setError] = useState(""); // 初期値は空文字
   // ページ遷移用のフック
@@ -41,12 +43,14 @@ const HomePage: React.FC = () => {
       await axios.post(`${process.env.REACT_APP_API_URL}/todos`, {
         title: task, // タスク名
         details: details, // 詳細情報
+        due_date: dueDate || null, // 締め切り日
         user_id: parseInt(userId), // ユーザーID（文字列を整数に変換）
       });
 
       // 入力フィールドをリセット
       setTask(""); // タスク名を空にする
       setDetails(""); // 詳細を空にする
+      setDueDate(""); // 締め切り日を空にする
       navigate("/list"); // タスク一覧ページに遷移
     } catch (err) {
       console.error("Failed to add task"); // タスク追加失敗時のエラー出力
@@ -87,6 +91,17 @@ const HomePage: React.FC = () => {
           margin="normal" // マージン設定
         />
 
+        {/* 締め切り日入力フィールド */}
+        <TextField
+          label="締め切り日"
+          type="date"
+          InputLabelProps={{ shrink: true }}
+          fullWidth
+          value={dueDate}
+          onChange={(e) => setDueDate(e.target.value)}
+          margin="normal"
+        />
+
         {/* タスク追加ボタン */}
         <Box mt={2}> {/* 上部にマージンを追加 */}
           <Button type="submit" variant="contained" color="primary" fullWidth>
@@ -103,6 +118,17 @@ const HomePage: React.FC = () => {
             onClick={() => navigate("/list")} // ボタン押下時にタスク一覧ページへ遷移
           >
             タスク一覧へ
+          </Button>
+        </Box>
+        {/* カレンダーページへの遷移ボタン */}
+        <Box mt={2}>
+          <Button
+            variant="outlined"
+            color="secondary"
+            fullWidth
+            onClick={() => navigate("/calendar")}
+          >
+            カレンダーへ
           </Button>
         </Box>
       </form>

--- a/frontend/src/pages/ListPage.tsx
+++ b/frontend/src/pages/ListPage.tsx
@@ -24,6 +24,7 @@ interface Todo {
   id: number; // タスクを一意に識別するID
   title: string; // タスクの名前
   details: string | null; // タスクの詳細情報（文字列またはnullを許容）
+  due_date: string | null; // 締め切り日
   completed: boolean; // タスクが完了しているかどうかを示すフラグ
 }
 
@@ -187,6 +188,11 @@ const ListPage: React.FC = () => {
                 {todo.details && ( /* 詳細情報が存在する場合のみ表示 */
                   <Typography variant="body2" color="textSecondary">
                     {todo.details} {/* タスクの詳細情報 */}
+                  </Typography>
+                )}
+                {todo.due_date && (
+                  <Typography variant="body2" color="textSecondary">
+                    期限: {todo.due_date}
                   </Typography>
                 )}
               </Box>


### PR DESCRIPTION
## Summary
- add optional due_date field to todo model and database schema
- handle due_date in backend routes
- allow inputting due date when creating a task
- display due date in list page
- add calendar page to view tasks by selected date
- wire calendar page into routing and navigation

## Testing
- `npm test` *(fails: react-scripts not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847c191dfd483328f023913818b02ab